### PR TITLE
Add users to seed and "seed delete" command

### DIFF
--- a/api/src/cs348_api/routes/seed.py
+++ b/api/src/cs348_api/routes/seed.py
@@ -1,11 +1,36 @@
 from flask import Blueprint
+from sqlalchemy.sql import text
 
 from cs348_api.extensions import db
 from cs348_api.models.food_item import FoodItem
 from cs348_api.models.restaurant import Restaurant
+from cs348_api.models.food_log import FoodLog
+from cs348_api.models.user import User
+from datetime import datetime
 
 seed = Blueprint("seed", __name__)
 
+@seed.cli.command("delete")
+def delete_all():
+    # delete contents of all tables to reset db
+    db.session.query(FoodLog).delete()
+    db.session.query(FoodItem).delete()
+    db.session.query(Restaurant).delete()
+    db.session.query(User).delete()
+    db.session.execute(text('ALTER TABLE food_log AUTO_INCREMENT=1'))
+    db.session.execute(text('ALTER TABLE food_item AUTO_INCREMENT=1'))
+    db.session.execute(text('ALTER TABLE restaurant AUTO_INCREMENT=1'))
+    db.session.execute(text('ALTER TABLE user AUTO_INCREMENT=1'))
+    db.session.commit()
+
+def add_food_logs(user, food_list, created_at):
+    food_logs = []
+    for food_item in food_list:
+        fl = FoodLog(user_id=user.id, food_item_id=food_item.id)
+        fl.created_at = created_at
+        food_logs.append(fl)
+    db.session.add_all(food_logs)
+    db.session.commit()
 
 @seed.cli.command("all")
 def seed_all():
@@ -24,9 +49,20 @@ def seed_all():
         restaurant_id=restaurant2.id, calories=360, fat=9, carb=43, protein=37)
     whopper_jr = FoodItem(name='Whopper Jr. Sandwich', restaurant_id=restaurant2.id,
         calories=310, fat=160, carb=18, fiber=2, protein=2)
-    db.session.add(big_mac)
-    db.session.add(bec)
-    db.session.add(pannini)
-    db.session.add(double_whopper)
-    db.session.add(whopper_jr)
+    db.session.add_all([big_mac, bec, pannini, double_whopper, whopper_jr])
     db.session.commit()
+
+    # add two sample users
+    tim = User(name="Tim Cook", email="tim@email.com", password="password", registration_date=datetime.utcnow())
+    jane = User(name="Jane Doe", email="jane@email.com", password="janedoe", registration_date=datetime.utcnow())
+    db.session.add(tim)
+    db.session.add(jane)
+    db.session.commit()
+
+    # add food logs for Tim and Jane
+    add_food_logs(tim, [big_mac, bec, pannini], '2023-06-4 15:00:00')
+    add_food_logs(tim, [double_whopper, whopper_jr], '2023-06-10 11:30:00')
+    add_food_logs(jane, [big_mac, pannini, bec], '2023-06-10 11:30:00')
+    add_food_logs(jane, [pannini], '2023-06-11 11:30:00')
+    add_food_logs(jane, [pannini, double_whopper, bec, whopper_jr], '2023-06-12 11:30:00')
+


### PR DESCRIPTION
Updates to `seed` commands:
- `seed all` now also seeds two users + some food logs for them
- `seed delete` is a new command that will reset the contents of your database - so to have fresh sample data for the db, you can `seed delete` before doing `seed all`.